### PR TITLE
Check that download is eligible to be downloaded and other misc related issues

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -60,7 +60,7 @@ function edd_free_download_process() {
         wp_die( __( 'An internal error has occurred, please try again or contact support.', 'edd-free-downloads' ), __( 'Oops!', 'edd-free-downloads' ) );
     }
     
-    if ( edd_is_bundled_product( $download_id ) ){
+    if ( edd_is_bundled_product( $download_id ) || edd_has_variable_prices( $download_id ) ){
         wp_die( __( 'An internal error has occurred, please try again or contact support.', 'edd-free-downloads' ), __( 'Oops!', 'edd-free-downloads' ) );
     }
     


### PR DESCRIPTION
Fixes:
Security 1: Download can be added to cart when the download is not published ( draft/trash/etc)

Security 2: Fixes email sanitation and validation

Security 3: Prevent variable prices from using modal

Bug 1: Download as bundle can be added to modal when Free Downloads doesn't support bundles.

Bug 2: Fixes lack of isset before nonce checking

Bug 3: Ensure download is download object before using it as an object 

Enhancement 1: Use more descriptive variable names