### PR TITLE
issue/161 and issue/196 Allowing EDD to go directly to the success page

### DIFF
--- a/includes/download-actions.php
+++ b/includes/download-actions.php
@@ -462,11 +462,29 @@ function edd_free_downloads_process_auto_download() {
 			'status'       => 'publish',
 		);
 
-		error_log('purchase data: ' . print_r($purchase_data, 1));
+		// error_log('purchase data: ' . print_r($purchase_data, 1));
 
-		error_log( 'download id: ' . $download_id );
+		// error_log( 'download id: ' . $download_id );
+
+		$edd_payment_check = get_posts( array(
+			'suppress_filters' => false,
+			'post_type' => 'edd_payment',
+			'meta_key' => '_edd_purchased_product',
+			'meta value' => $download_id,
+			'posts_per_page' => 1,
+		) );
+
+		error_log('edd_payment_check: ' . print_r($edd_payment_check, 1) );
 
 		$payment_id = edd_insert_payment( $purchase_data );
+
+		/**
+		 * Adding "purchased" product post ID to payment edd_payment post type
+		 * to allow for future queries to check if the user has already "purchased"
+		 * this free download. If so we will not create a new payment record,
+		 * i.e not creating a new edd_payment post.
+		 */
+		update_post_meta( $payment_id, '_edd_purchased_product', $download_id );
 
 		/**
 		 * Temporary code to ensure this will work

--- a/includes/download-actions.php
+++ b/includes/download-actions.php
@@ -255,9 +255,16 @@ function edd_free_download_process() {
 	$mobile_custom_url  = edd_get_option( 'edd_free_downloads_mobile_redirect', false );
 	$mobile_custom_url  = $mobile_custom_url ? esc_url( $mobile_custom_url ) : $success_page;
 	$apple_custom_url   = edd_get_option( 'edd_free_downloads_apple_redirect', false );
-	$appple_custom_url  = $apple_custom_url ? esc_url( $apple_custom_url ) : $success_page;
+	$apple_custom_url   = $apple_custom_url ? esc_url( $apple_custom_url ) : $success_page;
 	$mobile_on_complete = edd_get_option( 'edd_free_downloads_mobile_on_complete', 'default' );
 	$apple_on_complete  = edd_get_option( 'edd_free_downloads_apple_on_complete', 'default' );
+
+	/**
+	 * For non logged in users and no download file is selected. though not for logged in users.
+	 */
+	if ( empty( $download_files ) ) {
+		$on_complete = 'default';
+	}
 
 	switch ( $on_complete ) {
 		case 'default' :
@@ -401,6 +408,11 @@ function edd_free_downloads_process_auto_download() {
 		}
 
 		edd_free_downloads_download_file( $download_url, $hosted );
+	} else {
+		/**
+		 * Our $download_files array is empty because there are no files and the user is logged in
+		 */
+		wp_safe_redirect( edd_get_success_page_uri() );
 	}
 }
 add_action( 'edd_free_downloads_process_download', 'edd_free_downloads_process_auto_download' );

--- a/includes/download-actions.php
+++ b/includes/download-actions.php
@@ -414,7 +414,10 @@ function edd_free_downloads_process_auto_download() {
 		 */
 
 		/**
-		 * Adding purchase record for logged in user
+		 * Adding purchase record for logged in user.
+		 * Note the below logic will _not_ create a payment
+		 * record if the user is logged in though has already
+		 * "purchased" product.
 		 */
 
 		/**
@@ -430,9 +433,9 @@ function edd_free_downloads_process_auto_download() {
 
 		$customer = new EDD_Customer( $user->data->user_email );
 
-		$have_purchased = edd_has_user_purchased( $user_id, $download_id, $variable_price_id = null );
+		$has_purchased = edd_has_user_purchased( $user_id, $download_id, $variable_price_id = null );
 
-		if ( true === $have_purchased ) {
+		if ( true === $has_purchased ) {
 
 			/**
 			 * The logged in user has already "purchased" this item

--- a/includes/download-actions.php
+++ b/includes/download-actions.php
@@ -409,6 +409,11 @@ function edd_free_downloads_process_auto_download() {
 
 		edd_free_downloads_download_file( $download_url, $hosted );
 	} else {
+
+		if ( ! is_user_logged_in() ) {
+			return;
+		}
+
 		/**
 		 * Our $download_files array is empty because there are no files and the user is logged in
 		 */

--- a/includes/download-actions.php
+++ b/includes/download-actions.php
@@ -260,7 +260,7 @@ function edd_free_download_process() {
 	$apple_on_complete  = edd_get_option( 'edd_free_downloads_apple_on_complete', 'default' );
 
 	/**
-	 * For non logged in users and no download file is selected. though not for logged in users.
+	 * This accounts for logged in users when no download file is attached to the purchase.
 	 */
 	if ( empty( $download_files ) ) {
 		$on_complete = 'default';

--- a/includes/download-actions.php
+++ b/includes/download-actions.php
@@ -412,7 +412,20 @@ function edd_free_downloads_process_auto_download() {
 		/**
 		 * Our $download_files array is empty because there are no files and the user is logged in
 		 */
-		wp_safe_redirect( edd_get_success_page_uri() );
+
+		// error_log( print_r( $_GET, 1 ) );
+
+		/**
+		 * Temporary code to ensure this will work
+		 */
+		if ( ! isset( $_GET['payment-id'] ) ) {
+			$_GET['payment-id'] = time();
+		}
+
+		// error_log( print_r( $_GET, 1 ) );
+
+		wp_safe_redirect( add_query_arg( array( 'payment_key' => absint( $_GET['payment-id'] ) ), edd_get_success_page_uri() ) );
+
 	}
 }
 add_action( 'edd_free_downloads_process_download', 'edd_free_downloads_process_auto_download' );

--- a/includes/download-actions.php
+++ b/includes/download-actions.php
@@ -415,19 +415,12 @@ function edd_free_downloads_process_auto_download() {
 
 		/**
 		 * Adding purchase record for logged in user
-		 *
-		 * @todo Check if the user is purchasing the free product with no
-		 * download file a second ( or more time )
-		 *
-		 * @var array
 		 */
 
 		/**
 		 * Getting our logged in user info
-		 */
-
-		/**
-		 * This is needed to correctly get currently logged in
+		 *
+		 * This do_action is needed to correctly get currently logged in
 		 * user
 		 */
 		do_action( 'edd_pre_process_purchase' );
@@ -447,6 +440,10 @@ function edd_free_downloads_process_auto_download() {
 
 			global $edd_logs;
 
+			/**
+			 * The function get_connected_logs() takes an array using the same
+			 * parameters as get_posts
+			 */
 			$logs = $edd_logs->get_connected_logs( array(
 				'suppress_filters' => false,
 				'posts_per_page' => 1,
@@ -459,19 +456,12 @@ function edd_free_downloads_process_auto_download() {
 				) ),
 			) );
 
-			error_log( 'sales log: ' . print_r($logs, 1) );
-
 			$payment_id = get_post_meta( $logs[0], '_edd_log_payment_id', true );
 			$payment = edd_get_payment( $payment_id );
 
-			error_log('payment_key ' . print_r( $payment->key, 1 ) );
-
-
-			error_log( 'have_purchased ' .  $have_purchased );
-
 		} else {
 			/**
-			 * actually create a payment record
+			 * actually creating a payment record
 			 */
 			$payment = new EDD_Payment();
 			$payment->user_id = $customer->user_id;

--- a/includes/download-actions.php
+++ b/includes/download-actions.php
@@ -480,7 +480,7 @@ function edd_free_downloads_process_auto_download() {
 			$payment->save();
 		}
 
-		wp_safe_redirect( add_query_arg( array( 'payment_key' => $payment->key ), edd_get_success_page_uri() ) );
+		wp_safe_redirect( add_query_arg( array( 'payment_key' => $payment->key ), edd_get_success_page_uri() ) ); exit;
 
 	} // End if logged in and "purchasing" a free product with no download file.
 }


### PR DESCRIPTION
this is needed for free purchases that have no download file associated

addresses #161 

addresses #196 

If logged in or not the user should be sent directly to the success page