### PR TITLE
Remove the edd-add-to-cart class

### DIFF
--- a/includes/filters.php
+++ b/includes/filters.php
@@ -123,7 +123,7 @@ function edd_free_downloads_purchase_download_form( $purchase_form, $args ) {
 						<?php
 						if ( edd_is_ajax_enabled() ) {
 							echo apply_filters( 'edd_free_downloads_button_override', sprintf(
-								'<a class="edd-add-to-cart %1$s" href="' . $href . '" data-download-id="%3$s">%2$s</a>',
+								'<a class="%1$s" href="' . $href . '" data-download-id="%3$s">%2$s</a>',
 								$download_class,
 								$download_label,
 								$download_id


### PR DESCRIPTION
#229 This class is not needed or relevant, and is causing incorrect ajax callbacks to be fired when clicked.